### PR TITLE
Ajout de documentation basique

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,1 +1,31 @@
- 
+# Configuration
+
+Le fichier `config/config.json` définit les paramètres du bot :
+
+* `exchange`
+  - `name` : nom de l'exchange utilisé (ex. `binance`).
+  - `testnet` : active le mode test de l'exchange.
+  - `api_key` / `api_secret` : vos clés API.
+
+* `trading`
+  - `pairs` : liste des paires traitées.
+  - `initial_balance` : capital initial pour les simulations.
+  - `position_size` : part du capital utilisée par trade.
+  - `max_positions` : nombre maximal de positions ouvertes.
+  - `stop_loss` / `take_profit` : seuils par défaut appliqués aux ordres.
+
+* `strategy`
+  - `name` : nom de la stratégie active.
+  - `short_window` et `long_window` : périodes des moyennes mobiles.
+  - `trend_window` : période de détection de tendance.
+  - `timeframe` : intervalle de temps des bougies.
+  - `min_data_points` : nombre minimal de données avant de lancer la stratégie.
+
+* `risk_management`
+  - `max_drawdown` : perte maximale autorisée sur le capital.
+  - `daily_loss_limit` : perte maximale par jour.
+  - `position_sizing` : méthode de calcul de la taille de position.
+
+* `logging`
+  - `level` : niveau de verbosité des logs.
+  - `file` : fichier dans lequel les logs sont écrits.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,1 +1,26 @@
- 
+# Installation
+
+1. Clonez le dépôt :
+   ```bash
+   git clone https://github.com/yourusername/crypto-trading-bot.git
+   cd crypto-trading-bot
+   ```
+
+2. Créez un environnement virtuel et installez les dépendances :
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # Linux/Mac
+   venv\Scripts\activate     # Windows
+   pip install -r requirements.txt
+   ```
+
+3. Copiez le fichier `.env.example` puis renseignez vos clés API :
+   ```bash
+   cp .env.example .env
+   # Éditer .env
+   ```
+
+4. Lancez les tests pour vérifier l'installation :
+   ```bash
+   python run_tests.py
+   ```

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,1 +1,12 @@
- 
+# Stratégies
+
+## MultiSignalStrategy
+
+Cette stratégie regroupe plusieurs indicateurs : RSI, MACD, bandes de Bollinger,
+volume et croisements de moyennes mobiles. Chaque indicateur produit un signal
+entre -1 et 1. Le `WeightedScoreEngine` applique des poids à ces signaux pour
+obtenir un score global.
+
+Lorsque le score dépasse un seuil positif, la stratégie émet un ordre d'achat.
+En dessous d'un seuil négatif, elle recommande la vente. Les poids des indicateurs
+peuvent être ajustés dans le code pour affiner le comportement.


### PR DESCRIPTION
## Summary
- ajouter un guide d'installation succinct
- décrire les paramètres du fichier de configuration
- expliquer la stratégie `MultiSignalStrategy`

## Testing
- `pytest -q` *(échoue : ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845646333d88327a7e26edc15245fcd